### PR TITLE
Fix problem with package repo

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -37,7 +37,7 @@ class googlechrome::params {
   }
 
   $repo_repos = $::googlechrome_repo_repos ? {
-    undef   => 'non-free main',
+    undef   => 'main',
     default => $::googlechrome_repo_release
   }
 

--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -18,11 +18,12 @@ class googlechrome::repo::debian (
   $pin
 ) {
   apt::source { $repo_name:
-    location   => $baseurl,
-    release    => $release,
-    repos      => $repos,
-    key        => $key,
-    key_source => $key_source,
-    pin        => $pin,
+    location    => $baseurl,
+    release     => $release,
+    repos       => $repos,
+    key         => $key,
+    key_source  => $key_source,
+    pin         => $pin,
+    include_src => false,
   }
 }


### PR DESCRIPTION
It appears the repo has changed a little, with the non-free flag and
trying to install the source packages I got failures in apt-get update.

Tested from Ubuntu 12.04
